### PR TITLE
changes to compile with musl libc?

### DIFF
--- a/src/fopen64.c
+++ b/src/fopen64.c
@@ -19,11 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_FOPEN64
-
 #define _LARGEFILE64_SOURCE
 #include <stdio.h>
+
+#if defined(HAVE_FOPEN64) && !defined(fopen64)
+
 #include "libfakechroot.h"
 
 

--- a/src/freopen64.c
+++ b/src/freopen64.c
@@ -19,11 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_FREOPEN64
-
 #define _LARGEFILE64_SOURCE
 #include <stdio.h>
+
+#if defined(HAVE_FREOPEN64) && !defined(freopen64)
+
 #include "libfakechroot.h"
 
 

--- a/src/fstatat64.c
+++ b/src/fstatat64.c
@@ -19,14 +19,14 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_FSTATAT64
-
 #define _ATFILE_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #define _LARGEFILE64_SOURCE
 #include <sys/stat.h>
 #include <limits.h>
+
+#if defined(HAVE_FSTATAT64) && !defined(fstatat64)
+
 #include "libfakechroot.h"
 
 wrapper(fstatat64, int, (int dirfd, const char *pathname, struct stat64 *buf, int flags))

--- a/src/ftw.c
+++ b/src/ftw.c
@@ -72,6 +72,8 @@ char *alloca ();
 #include <string.h>
 #include <unistd.h>
 
+#if !(defined(__FTW64_C) && defined(ftw64))
+
 /* By default we have none.  Map the name to the normal functions.  */
 #define open_not_cancel(name, flags, mode) \
   __libc_open (name, flags, mode)
@@ -196,6 +198,17 @@ int rpl_lstat (const char *, struct stat *);
 # endif
 # define FTW_FUNC_T __ftw_func_t
 # define NFTW_FUNC_T __nftw_func_t
+#endif
+#ifndef __GLIBC__
+  typedef int (*__ftw_func_t)(const char *, const struct stat *, int);
+  typedef int (*__nftw_func_t)(const char *, const struct stat *, int, struct FTW *);
+#endif
+#if !NEW_GLIBC
+# define FTW_ACTIONRETVAL 16
+# define FTW_CONTINUE 0
+# define FTW_STOP 1
+# define FTW_SKIP_SUBTREE 2
+# define FTW_SKIP_SIBLINGS 3
 #endif
 
 #define macro_stringify(name) macro_stringify2(name)
@@ -585,7 +598,7 @@ fail:
 
   /* Next, update the `struct FTW' information.  */
   ++data->ftw.level;
-  startp = __rawmemchr (data->dirbuf, '\0');
+  startp = strchr (data->dirbuf, '\0');
   /* There always must be a directory name.  */
   assert (startp != data->dirbuf);
   if (startp[-1] != '/')
@@ -934,6 +947,10 @@ NFTW_OLD_NAME (path, func, descriptors, flags)
 compat_symbol (libc, NFTW_OLD_NAME, NFTW_NAME, GLIBC_2_1);
 # endif
 #endif
+#endif
+
+#else
+typedef int empty_translation_unit;
 #endif
 
 #else

--- a/src/glob64.c
+++ b/src/glob64.c
@@ -19,11 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_GLOB64
-
 #define _LARGEFILE64_SOURCE
 #include <glob.h>
+
+#if defined(HAVE_GLOB64) && !defined(glob64)
+
 #include "libfakechroot.h"
 
 

--- a/src/mkostemp64.c
+++ b/src/mkostemp64.c
@@ -19,12 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_MKOSTEMP64
-
 #define _GNU_SOURCE
 #define _LARGEFILE64_SOURCE
 #include <stdlib.h>
+
+#if defined(HAVE_MKOSTEMP64) && !defined(mkostemp64)
 
 #include "libfakechroot.h"
 #include "strlcpy.h"

--- a/src/mkostemps64.c
+++ b/src/mkostemps64.c
@@ -19,13 +19,12 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_MKOSTEMPS64
-
 #define _GNU_SOURCE
 #define _LARGEFILE64_SOURCE
 #include <errno.h>
 #include <stdlib.h>
+
+#if defined(HAVE_MKOSTEMPS64) && !defined(mkostemps64)
 
 #include "libfakechroot.h"
 #include "strlcpy.h"

--- a/src/mkstemp64.c
+++ b/src/mkstemp64.c
@@ -19,13 +19,12 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_MKSTEMP64
-
 #define _LARGEFILE64_SOURCE
 #define _BSD_SOURCE
 #define _DEFAULT_SOURCE
 #include <stdlib.h>
+
+#if defined(HAVE_MKSTEMP64) && !defined(mkstemp64)
 
 #include "libfakechroot.h"
 #include "strlcpy.h"

--- a/src/mkstemps64.c
+++ b/src/mkstemps64.c
@@ -19,13 +19,12 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_MKSTEMPS64
-
 #define _DEFAULT_SOURCE
 #define _LARGEFILE64_SOURCE
 #include <errno.h>
 #include <stdlib.h>
+
+#if defined(HAVE_MKSTEMPS64) && !defined(mkstemps64)
 
 #include "libfakechroot.h"
 #include "strlcpy.h"

--- a/src/open64.c
+++ b/src/open64.c
@@ -19,13 +19,13 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_OPEN64
-
 #define _LARGEFILE64_SOURCE
 #include <stdarg.h>
 #include <stddef.h>
 #include <fcntl.h>
+
+#if defined(HAVE_OPEN64) && !defined(open64)
+
 #include "libfakechroot.h"
 
 

--- a/src/openat64.c
+++ b/src/openat64.c
@@ -19,14 +19,14 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_OPENAT64
-
 #define _LARGEFILE64_SOURCE
 #define _ATFILE_SOURCE
 #include <stdarg.h>
 #include <stddef.h>
 #include <fcntl.h>
+
+#if defined(HAVE_OPENAT64) && !defined(openat64)
+
 #include "libfakechroot.h"
 
 

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -37,7 +37,11 @@
  * as potentially configured in /etc/nsswitch.conf.
  */
 
-#include <gnu/libc-version.h>
+#if defined __has_include
+#  if __has_include(<gnu/libc-version.h>)
+#    include <gnu/libc-version.h>
+#  endif
+#endif
 #if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 32)
 
 #include <stdlib.h>

--- a/src/scandir64.c
+++ b/src/scandir64.c
@@ -19,11 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_SCANDIR64
-
 #define _LARGEFILE64_SOURCE
 #include <dirent.h>
+
+#if defined(HAVE_SCANDIR64) && !defined(scandir64)
+
 #include "libfakechroot.h"
 
 

--- a/src/setenv.c
+++ b/src/setenv.c
@@ -48,6 +48,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+extern char **environ;
 
 
 /* If this variable is not a null pointer we allocated the current
@@ -74,7 +75,7 @@ static int __add_to_environ(const char *name, const char *value,
 
         /* We have to get the pointer now that we have the lock and not earlier
            since another thread might have created a new environment.  */
-        ep = __environ;
+        ep = environ;
 
         size = 0;
         if (ep != NULL) {
@@ -98,10 +99,10 @@ static int __add_to_environ(const char *name, const char *value,
                 __set_errno(ENOMEM);
                 goto DONE;
         }
-        if (__environ != last_environ) {
-                memcpy(new_environ, __environ, size * sizeof(char *));
+        if (environ != last_environ) {
+                memcpy(new_environ, environ, size * sizeof(char *));
         }
-        last_environ = __environ = new_environ;
+        last_environ = environ = new_environ;
 
         ep = &new_environ[size];
         /* Ensure env is NULL terminated in case malloc below fails */
@@ -152,7 +153,7 @@ LOCAL int __unsetenv(const char *name)
         }
         len = eq - name; /* avoiding strlen this way */
 
-        ep = __environ;
+        ep = environ;
         /* NB: clearenv(); unsetenv("foo"); should not segfault */
         if (ep) while (*ep != NULL) {
                 if (!strncmp(*ep, name, len) && (*ep)[len] == '=') {
@@ -180,7 +181,7 @@ LOCAL int __clearenv(void)
         free(last_environ);
         last_environ = NULL;
         /* Clearing environ removes the whole environment.  */
-        __environ = NULL;
+        environ = NULL;
         return 0;
 }
 

--- a/src/statfs64.c
+++ b/src/statfs64.c
@@ -19,11 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_STATFS64
-
 #define _LARGEFILE64_SOURCE
 #include <sys/statfs.h>
+
+#if defined(HAVE_STATFS64) && !defined(statfs64)
+
 #include "libfakechroot.h"
 
 

--- a/src/statvfs64.c
+++ b/src/statvfs64.c
@@ -19,11 +19,11 @@
 
 
 #include <config.h>
-
-#ifdef HAVE_STATVFS64
-
 #define _LARGEFILE64_SOURCE
 #include <sys/statvfs.h>
+
+#if defined(HAVE_STATVFS64) && !defined(statvfs64)
+
 #include "libfakechroot.h"
 
 

--- a/src/utime.c
+++ b/src/utime.c
@@ -19,10 +19,11 @@
 
 
 #include <config.h>
-
 #include <utime.h>
-#include "libfakechroot.h"
 
+#if !_REDIR_TIME64
+
+#include "libfakechroot.h"
 
 wrapper(utime, int, (const char * filename, const struct utimbuf * buf))
 {
@@ -32,3 +33,7 @@ wrapper(utime, int, (const char * filename, const struct utimbuf * buf))
     expand_chroot_path(filename);
     return nextcall(utime)(filename, buf);
 }
+
+#else
+typedef int empty_translation_unit;
+#endif


### PR DESCRIPTION
I don’t really know what I’m doing, but I poked at this until it compiled on alpine. I’m curious if you have any comments or if it still works on glibc.

- added checks to some guards that functions are not macros or symbolic redirects
- used faster and normative strchr instead of rawmemchr which isn’t present
- a little code where symbols for gnu extensions are used